### PR TITLE
Set GIT_SSH_VARIANT=ssh for new release of Git

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -7,7 +7,8 @@ LABEL dockerImage.teamcity.version="latest" \
 
 ENV NUGET_XMLDOC_MODE=skip \
     DOTNET_CLI_TELEMETRY_OPTOUT=true \
-    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true \
+    GIT_SSH_VARIANT=ssh
 
 RUN apt-get update && \
     apt-get install -y software-properties-common && \


### PR DESCRIPTION
Explicitly set GIT_SSH_VARIANT environment variable, fixes SSH tool detection when SSH URL contains a port.

(related to recent PR: https://github.com/JetBrains/teamcity-docker-agent/pull/18#event-1539594850)

Per [StackOverflow # 48417505](https://stackoverflow.com/questions/48417505/fatal-ssh-variant-simple-does-not-support-setting-port):

> "The internal behavior of Git (>=2.16.0) for SSH tool detection changed.
>    ...
>    This only affects if the SSH URL contains a port. For now, you need to
>    set the environment variable GIT_SSH_VARIANT to ssh"