### PR TITLE
Add an alpine agent image

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,0 +1,53 @@
+FROM jetbrains/teamcity-minimal-agent:2019.1.4-alpine
+
+LABEL dockerImage.teamcity.version="latest" \
+      dockerImage.teamcity.buildNumber="latest"
+
+    # Opt out of the telemetry feature
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=true \
+    # Disable first time experience
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true \
+    # Configure Kestrel web server to bind to port 80 when present
+    ASPNETCORE_URLS=http://+:80 \
+    # Enable detection of running in a container
+    DOTNET_RUNNING_IN_CONTAINER=true \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps perfomance
+    NUGET_XMLDOC_MODE=skip \
+    GIT_SSH_VARIANT=ssh \
+    # Install .NET Core SDK
+    DOTNET_SDK_VERSION=3.0.101
+
+RUN apk update && \
+    apk add curl git mercurial ca-certificates docker && \
+    curl -SL https://github.com/docker/compose/releases/download/1.23.2/docker-compose-Linux-x86_64 -o /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose && \
+    apk add fontconfig \
+            libc6-compat \
+            libunwind-dev \
+            libintl \
+            libgcc \
+            krb5-libs \
+            icu-libs \
+            lttng-ust-dev \
+            libssl1.1 \
+            libstdc++ \
+            zlib \
+        && rm -rf /var/lib/apt/lists/* && \
+    \
+    wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \
+    && dotnet_sha512='98cc98f58187d208bd388f8c71862ea75e50ca25666e265f40a4e7c28082c2784738172e8ae4af7815057f7c57072cbe4fc03301d01738fc1ed5bb5e4d30a363' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && rm dotnet.tar.gz && \
+    addgroup buildagent docker
+
+# A better fix for TW-52939 Dockerfile build fails because of aufs
+VOLUME /var/lib/docker
+
+COPY run-docker.sh /services/run-docker.sh
+
+# Trigger .NET CLI first run experience by running arbitrary cmd to populate local package cache
+RUN dotnet help

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 if [ "$DOCKER_IN_DOCKER" = "start" ] ; then
- rm /var/run/docker.pid 2>/dev/null
- service docker start
- echo "Docker daemon started"
+  rm /var/run/docker.pid 2>/dev/null
+  if [ -x "$(command -v service)" ]; then
+    service docker start
+  else
+    dockerd >/tmp/docker.stdout 2>/tmp/docker.stderr &
+  fi
+    echo "Docker daemon started"
 fi


### PR DESCRIPTION
This adds a new image based on alpine linux that should be equivalent to the current Ubuntu agent.

This requires the image from JetBrains/teamcity-docker-minimal-agent#37